### PR TITLE
dockerize the tool

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM jrottenberg/ffmpeg:3.4-scratch as ffmpeg
+FROM python:3-alpine
+
+COPY --from=ffmpeg /bin/ffmpeg /usr/local/bin/ffmpeg
+
+# install the pip libraries required
+## todo: optimize this
+RUN echo "http://dl-8.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories \
+  && apk --no-cache --update-cache add gcc gfortran jpeg-dev python python-dev py-pip build-base wget freetype-dev libpng-dev openblas-dev \
+  && pip install youtube_dl numpy Pillow
+
+# completely optional
+WORKDIR /usr/src/app
+
+# /bin/sh so we can execute whatever command we tell it to
+ENTRYPOINT ["/bin/sh", "-c"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,6 @@
+.PHONY: docker-build docker-run
+
+docker-build:
+	docker build -t codeagif .
+docker-run:
+	docker run --rm -ti -v `pwd`:/usr/src/app codeagif:latest "/usr/local/bin/python /usr/src/app/main_script_en.py"

--- a/README.md
+++ b/README.md
@@ -25,3 +25,31 @@ Basically, as the gif says:
 
 And voilà.  
 But honestly, you might prefer to just stick to KDEnlive or your favorite video editor :)
+
+## Dockerized
+
+You can leverage Docker containers to code up a GIF. The only requirement you need is [Docker](https://docs.docker.com/install/).
+
+### Run the docker image with this repository
+
+To run the Docker container in an environment specific to this repository:
+
+```
+# clone this repo
+$ git clone https://github.com/1-Sisyphe/youCanCodeAGif
+
+# make sure the repo is your current working directory
+$ cd youCanCodeAGif
+
+# docker run the docker image (it mounts the cwd to "/usr/src/app")
+$ docker run --rm -ti -v `pwd`:/usr/src/app slikshooz/youcancodeagif:latest "python main_script.py"
+```
+
+### Create dockerimage
+
+For those of you who would rather build it themselves, here is a way to use the same Dockerfile
+
+```
+# Build the image locally
+$ docker build -t youcancodeagif .
+```


### PR DESCRIPTION
I managed to (inefficiently) squeeze the `youCanCodeAGif` into a Docker-based solution to make it easier for others to not worry about the dependency chain involved.

I added a readme entry to help highlight how to use it. I know I used references to my assets, and I'm more than happy to change that to yours if you choose to build them as well.

Docker Hub repo for reference: https://hub.docker.com/r/slikshooz/youcancodeagif/